### PR TITLE
Update 'An End to Negativity' talk with working link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As usual, **pull requests are encouraged**. I'll be updating this regularly but 
 ### Talks (in no particular order)
 
 * [Simple Made Easy](http://www.infoq.com/presentations/Simple-Made-Easy) (**Rich Hickey, Strange Loop 2011**) Hickey talk 1 of N that's worth every minute (even if you don't care at all about programming).
-* [An End to Negativity](http://jsconf.eu/2011/an_end_to_negativity.html) (**Chris Williams, JSConf.eu 2011**) Pure passion. 
+* [An End to Negativity](https://www.youtube.com/watch?v=17rkSdkc5TI) (**Chris Williams, JSConf.eu 2011**) Pure passion. 
 * [Surge 2011 Key Note](http://www.youtube.com/watch?v=gNhn-bNc96Y) (**Ben Fried, Surge 2011**) Lessons learned and practical advice related to the importance of being a technical generalist. Also, no slides; few can pull this off well. 
 * [Inventing on Principle](https://vimeo.com/36579366) (**Bret Victor, CUSEC 2012**) Driven thinker and technologist talking about important things. 
 * [WAT](https://www.destroyallsoftware.com/talks/wat) (**Gary Bernardt, CodeMash 2012**) Hilarious and entertaining. Arguably a perfect lightning talk. 


### PR DESCRIPTION
The link to http://jsconf.eu/2011/an_end_to_negativity.html works, but the embedded video has been removed.

Added a link to the video on YouTube (https://www.youtube.com/watch?v=17rkSdkc5TI) and hopefully that one will stay around.
